### PR TITLE
Fix typo in command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sh ./configure.sh
 
 **GUI version**
 ```
- java –jar GUAVA.jar
+ java -jar GUAVA.jar
 ```
 
 <br/>


### PR DESCRIPTION
Replaces the em dash with a short one in the GUI launch example, as it resulted in an error when launching. This is related to #23 #26.